### PR TITLE
Always build OpenCV with CMAKE_BUILD_TYPE=Release (fix #14)

### DIFF
--- a/debian/rules.em
+++ b/debian/rules.em
@@ -25,8 +25,10 @@ override_dh_auto_configure:
 	# In case we're installing to a non-standard location, look for a setup.sh
 	# in the install tree that was dropped by catkin, and source it.  It will
 	# set things like CMAKE_PREFIX_PATH, PKG_CONFIG_PATH, and PYTHONPATH.
+	# OpenCV needs to be built with CMAKE_BUILD_TYPE Release or (empty), but not
+	# with None as set by debhelper.
 	if [ -f "@(InstallationPrefix)/setup.sh" ]; then . "@(InstallationPrefix)/setup.sh"; fi && \
-	dh_auto_configure -- -DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)"
+	dh_auto_configure -- -DCMAKE_INSTALL_PREFIX="@(InstallationPrefix)" -DCMAKE_BUILD_TYPE=Release
 
 override_dh_auto_build:
 	# In case we're installing to a non-standard location, look for a setup.sh


### PR DESCRIPTION
... to fix `RelWithDebInfo` builds of derived packages.
There might be several other options to fix the problem, e.g. by patching upstream OpenCV.

I verified that bloom properly exports the patch and reapplies it for each new release (in kinetic) once this pull request would be merged. The same patch should be applied to `debian/lunar/opencv3`, which has the same version and is probably also affected.