### PR TITLE
[CUDA]Add --expt-relaxed-constexpr to allow constexpr in device codes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -730,6 +730,7 @@ unset(_hal_includes)
 # Add CUDA libraries (needed for apps/tools, samples)
 # ----------------------------------------------------------------------------
 if(HAVE_CUDA)
+  set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} --expt-relaxed-constexpr")
   set(OPENCV_LINKER_LIBS ${OPENCV_LINKER_LIBS} ${CUDA_LIBRARIES} ${CUDA_npp_LIBRARY})
   if(HAVE_CUBLAS)
     set(OPENCV_LINKER_LIBS ${OPENCV_LINKER_LIBS} ${CUDA_cublas_LIBRARY})


### PR DESCRIPTION
Hi guys. Today I found a problem when compiling CUDA codes. That is caused by lack of an nvcc flag that allows a constexpr __device__ function. 